### PR TITLE
Update to 10.11.0 version of Seil

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,7 +3,7 @@
 # $dmg_url - where to download the dmg
 # $app - location of installed application
 class seil::config {
-  $version = '10.9.0'
+  $version = '10.11.0'
   $base_url = 'https://pqrs.org/macosx/keyremap4macbook/files'
   $dmg_url = "${base_url}/Seil-${version}.dmg"
   $app = '/Applications/Seil.app'


### PR DESCRIPTION
The current version of Seil is 10.11.0 - support that.