### PR TITLE
Minor grep command fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Installs [Seil](https://pqrs.org/macosx/keyremap4macbook/seil.html.en) on your M
 ## Usage
 
 ```puppet
+# Just install seil
 include seil
 
-# add seil to login items:
+# Install seil and add seil to login items:
 include seil::login_item
 
 # change the left control to F19:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,7 +3,7 @@
 # $dmg_url - where to download the dmg
 # $app - location of installed application
 class seil::config {
-  $version = '10.9.0'
+  $version = '10.11.0'
   $base_url = 'https://pqrs.org/macosx/keyremap4macbook/files'
   $dmg_url = "${base_url}/Seil-${version}.dmg"
   $app = '/Applications/Seil.app'

--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -24,12 +24,12 @@ define seil::exec($command = $title, $unless = undef, $onlyif = undef) {
 
   $unless_changed = $unless ? {
     undef   => undef,
-    default => "${seil::config::cli} export | grep ${unless}"
+    default => "${seil::config::cli} export | grep '${unless}'"
   }
 
   $onlyif_changed = $onlyif ? {
     undef   => undef,
-    default => "${seil::config::cli} export | grep ${onlyif}"
+    default => "${seil::config::cli} export | grep '${onlyif}'"
   }
 
   exec { "seil::exec ${command}":

--- a/manifests/login_item.pp
+++ b/manifests/login_item.pp
@@ -16,6 +16,7 @@
 #
 #   ensure - 'present' or 'absent'. Defaults to 'present'.
 class seil::login_item($ensure = 'present') {
+  include seil
   include seil::config
 
   osx_login_item { 'Seil':

--- a/spec/defines/exec_spec.rb
+++ b/spec/defines/exec_spec.rb
@@ -47,7 +47,7 @@ describe 'seil::exec' do
       should contain_exec('seil::exec keycode_capslock 80').with({
         :command => "#{cli} keycode_capslock 80",
         :require => "Exec[launch seil#{version}]",
-        :unless => "#{cli} export | grep keycode_capslock 80"
+        :unless => "#{cli} export | grep 'keycode_capslock 80'"
       })
     end
   end
@@ -65,7 +65,7 @@ describe 'seil::exec' do
       should contain_exec('seil::exec keycode_capslock 80').with({
         :command => "#{cli} keycode_capslock 80",
         :require => "Exec[launch seil#{version}]",
-        :onlyif => "#{cli} export | grep keycode_capslock 80"
+        :onlyif => "#{cli} export | grep 'keycode_capslock 80'"
       })
     end
   end


### PR DESCRIPTION
I was seeing an issue where, when boxen was checking to see if a key was already set it was calling grep with the search term unquoted, causing grep to try and grep inside a file by default in OS X 10.10 if there are spaces in the term.

Ie was:
    grep enable_capslock 80
should have been:
    grep 'enable_capslock 80'

This patch should be all fine unless Seil starts using single quotes in it's commands.
