### PR TITLE
Quote grep patterns in default unless_changed and onlyif_changed in seil::exec

### DIFF
--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -24,12 +24,12 @@ define seil::exec($command = $title, $unless = undef, $onlyif = undef) {
 
   $unless_changed = $unless ? {
     undef   => undef,
-    default => "${seil::config::cli} export | grep ${unless}"
+    default => "${seil::config::cli} export | grep \"${unless}\""
   }
 
   $onlyif_changed = $onlyif ? {
     undef   => undef,
-    default => "${seil::config::cli} export | grep ${onlyif}"
+    default => "${seil::config::cli} export | grep \"${onlyif}\""
   }
 
   exec { "seil::exec ${command}":

--- a/spec/defines/exec_spec.rb
+++ b/spec/defines/exec_spec.rb
@@ -47,7 +47,7 @@ describe 'seil::exec' do
       should contain_exec('seil::exec keycode_capslock 80').with({
         :command => "#{cli} keycode_capslock 80",
         :require => "Exec[launch seil#{version}]",
-        :unless => "#{cli} export | grep keycode_capslock 80"
+        :unless => "#{cli} export | grep \"keycode_capslock 80\""
       })
     end
   end
@@ -65,7 +65,7 @@ describe 'seil::exec' do
       should contain_exec('seil::exec keycode_capslock 80').with({
         :command => "#{cli} keycode_capslock 80",
         :require => "Exec[launch seil#{version}]",
-        :onlyif => "#{cli} export | grep keycode_capslock 80"
+        :onlyif => "#{cli} export | grep \"keycode_capslock 80\""
       })
     end
   end


### PR DESCRIPTION
This fixes a minor annoyance I have with this module where seil::exec will be run for each seil::map resource regardless of if it already exists. It looks like the problem was the default unless and onlyif parameters to seil::exec were not quoting the pattern to be searched for in seil's exported config, effectively ensuring that the grep always failed.